### PR TITLE
Fix Memcache namespace undefined

### DIFF
--- a/src/Mouf/Utils/Cache/MemcacheCache.php
+++ b/src/Mouf/Utils/Cache/MemcacheCache.php
@@ -2,6 +2,7 @@
 namespace Mouf\Utils\Cache;
 use Mouf\Utils\Log\LogInterface;
 use Psr\Log\LoggerInterface;
+use Memcache;
 /**
  * This package contains a cache mechanism that relies on Memcache lib.
  * 


### PR DESCRIPTION
En utilisant le plugin, j'ai été confronté à une exception indiquant que Utils/Mouf/Memcache n'était pas définit.

Problème rencontré sur Nginx avec Php-FPM (dernière version des dépots sur Ubuntu 14.04)

Avec l'ajout d'un "use Memcache", on évite ce problème.
